### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,59 @@
 {
-    "name": "boomcatch",
-    "version": "3.1.3",
-    "description": "A standalone, node.js-based beacon receiver for boomerang.",
-    "homepage": "https://github.com/springernature/boomcatch",
-    "bugs": "https://github.com/springernature/boomcatch/issues",
-    "license": "GPL-3.0+",
-    "author": "Springer Nature (https://github.com/springernature)",
-    "main": "./src",
-    "bin": {
-        "boomcatch": "./src/cli.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/springernature/boomcatch.git"
-    },
-    "keywords": [
-        "boomerang",
-        "kylie",
-        "beacon",
-        "server",
-        "receiver",
-        "forwarder",
-        "mapper",
-        "marshaller",
-        "rum",
-        "metric",
-        "monitoring",
-        "performance"
-    ],
-    "dependencies": {
-        "check-types": "~3.2.0",
-        "commander": "~2.9.0",
-        "get-off-my-log": "~0.1.0",
-        "qs": "~3.1.0",
-        "useragent": "~2.1.8",
-        "yamlparser": "~0.0.2",
-        "request": "~2.74.0",
-        "node-uuid": "~1.4.7",
-        "toobusy-js": "~0.5.1",
-        "handlebars": "~4.0.5",
-        "ua-parser-js": "~0.7.10"
-    },
-    "optionalDependencies": {
-        "ain2": "~2.0.0"
-    },
-    "devDependencies": {
-        "jshint": "~2.9.0",
-        "mocha": "~3.0.2",
-        "chai": "~3.0.0",
-        "mockery": "~1.4.0",
-        "spooks": "~2.0.0",
-        "cheerio": "~0.19.0"
-    },
-    "scripts": {
-        "lint": "jshint src --config .jshintrc",
-        "test": "mocha --ui tdd --reporter spec --recursive --colors test"
-    }
+  "name": "boomcatch",
+  "version": "3.1.3",
+  "description": "A standalone, node.js-based beacon receiver for boomerang.",
+  "homepage": "https://github.com/springernature/boomcatch",
+  "bugs": "https://github.com/springernature/boomcatch/issues",
+  "license": "GPL-3.0+",
+  "author": "Springer Nature (https://github.com/springernature)",
+  "main": "./src",
+  "bin": {
+    "boomcatch": "./src/cli.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/springernature/boomcatch.git"
+  },
+  "keywords": [
+    "boomerang",
+    "kylie",
+    "beacon",
+    "server",
+    "receiver",
+    "forwarder",
+    "mapper",
+    "marshaller",
+    "rum",
+    "metric",
+    "monitoring",
+    "performance"
+  ],
+  "dependencies": {
+    "check-types": "~3.2.0",
+    "commander": "~2.9.0",
+    "get-off-my-log": "~0.1.0",
+    "handlebars": "~4.0.5",
+    "qs": "~3.1.0",
+    "request": "~2.74.0",
+    "toobusy-js": "~0.5.1",
+    "ua-parser-js": "~0.7.10",
+    "useragent": "~2.1.8",
+    "uuid": "^3.0.0",
+    "yamlparser": "~0.0.2"
+  },
+  "optionalDependencies": {
+    "ain2": "~2.0.0"
+  },
+  "devDependencies": {
+    "jshint": "~2.9.0",
+    "mocha": "~3.0.2",
+    "chai": "~3.0.0",
+    "mockery": "~1.4.0",
+    "spooks": "~2.0.0",
+    "cheerio": "~0.19.0"
+  },
+  "scripts": {
+    "lint": "jshint src --config .jshintrc",
+    "test": "mocha --ui tdd --reporter spec --recursive --colors test"
+  }
 }
-

--- a/src/forwarders/file.js
+++ b/src/forwarders/file.js
@@ -21,7 +21,7 @@
 
 var fs = require('fs'),
     path = require('path'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     extensions;
 
 exports.initialise = function (options) {

--- a/test/forwarders/file.js
+++ b/test/forwarders/file.js
@@ -27,7 +27,7 @@ modulePath = '../../src/forwarders/file';
 
 mockery.registerAllowable(modulePath);
 mockery.registerAllowable('check-types');
-mockery.registerAllowable('node-uuid');
+mockery.registerAllowable('uuid');
 mockery.registerAllowable('crypto');
 
 suite('forwarders/file:', function () {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.