### PR TITLE
Fix documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ boomcatch.listen({
     ],
     limit: 100,                               // Defaults to 0
     maxSize: 1048576,                         // Defaults to -1
-    log: console.log,                         // Defaults to function () {}
+    log: console,                             // Defaults to function () {}
     workers: require('os').cpus().length,     // Defaults to 0
     validator: path.resolve('./myvalidator'), // Defaults to 'permissive'
     mapper: path.resolve('./mymapper'),       // Defaults to 'statsd'

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ boomcatch.listen({
     ],
     limit: 100,                               // Defaults to 0
     maxSize: 1048576,                         // Defaults to -1
-    log: console,                             // Defaults to function () {}
+    log: console,                             // Defaults to object with `info`, `warn` and `error` log functions.
     workers: require('os').cpus().length,     // Defaults to 0
     validator: path.resolve('./myvalidator'), // Defaults to 'permissive'
     mapper: path.resolve('./mymapper'),       // Defaults to 'statsd'


### PR DESCRIPTION
Resolves #69 

Logs in Boomcatch must be objects. Boomcatch verifies this to make sure it's correct, and returns an error if a log is anything other than an object.

Since `console.log` is a function, the documentation currently tells you to configure your script so that it throws an error 😁 