### PR TITLE
Update qs to 6.3.1 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "~2.9.0",
     "get-off-my-log": "~0.1.0",
     "handlebars": "~4.0.5",
-    "qs": "~3.1.0",
+    "qs": "~6.3.1",
     "request": "~2.74.0",
     "toobusy-js": "~0.5.1",
     "ua-parser-js": "~0.7.10",

--- a/src/index.js
+++ b/src/index.js
@@ -680,7 +680,7 @@ function send (log, state, remoteAddress, validator, filter, mapper, forwarder, 
 function parseData (request, state) {
     if (request.method === 'GET') {
         state.successStatus = 204;
-        return qs.parse(url.parse(request.url).query);
+        return qs.parse(url.parse(request.url).query, { allowDots: true });
     }
 
     state.successStatus = 200;

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,11 @@ mockery.registerAllowable('./lib/');
 mockery.registerAllowable('./stringify');
 mockery.registerAllowable('./utils');
 mockery.registerAllowable('./parse');
+mockery.registerAllowable('./v1');
+mockery.registerAllowable('./v4');
+mockery.registerAllowable('./lib/rng');
+mockery.registerAllowable('./lib/bytesToUuid');
+mockery.registerAllowable('./formats');
 
 process.setMaxListeners(500);
 


### PR DESCRIPTION
* Fixes [https://snyk.io/vuln/npm:qs:20170213](https://snyk.io/vuln/npm:qs:20170213)
* Suppress mockery warnings introduced by the new qs version.