### PR TITLE
Appended newline to data in file forwarder

### DIFF
--- a/src/forwarders/file.js
+++ b/src/forwarders/file.js
@@ -32,7 +32,7 @@ function send (directory, data, type, separator, callback) {
     try {
         fs.writeFile(
             path.join(directory, 'boomcatch-' + uuid.v4() + '.' + extensions[type || 'default']),
-            data,
+            data + '\n',
             { mode: 420 },
             function (error) {
                 callback(error, data.length);

--- a/test/forwarders/file.js
+++ b/test/forwarders/file.js
@@ -152,7 +152,7 @@ suite('forwarders/file:', function () {
                     assert.strictEqual(log.these.writeFile[0], require('fs'));
                     assert.lengthOf(log.args.writeFile[0], 4);
                     assert.strictEqual(log.args.writeFile[0][0], 'mock path.join result');
-                    assert.strictEqual(log.args.writeFile[0][1], 'foo bar');
+                    assert.strictEqual(log.args.writeFile[0][1], 'foo bar\n');
                     assert.isObject(log.args.writeFile[0][2]);
                     assert.lengthOf(Object.keys(log.args.writeFile[0][2]), 1);
                     assert.strictEqual(log.args.writeFile[0][2].mode, 420);


### PR DESCRIPTION
Hi, team,

I've been using Boomcatch together with ELK stacks, my solution depends on **unmapped** mapper and **file** forwarder, and then let FileBeat to collect generated json files. However FileBeat doesn't recognize any record if a json file doesn't end with newline (`\n`).

When I read Boomcatch source code, I think I could append the newline (`\n`) to the end of `data` in file forwarder, and I guess it won't break any downstream usages.

I've also adjusted UT.

Could you please help review this PR?

Thanks.
