### PR TITLE
Add some details about extensions to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ boomcatch.listen({
 
 Boomcatch implements four extension points to control how beacon requests are handled: validators, filters, mappers and forwarders.
 
-[Read more about them here][extensions].
+Several extensions are shipped as part of Boomcatch, or you can implement your own custom extensions.
+
+You can read more details in the [documentation about extensions][extensions].
 
 ## Development
 

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -1,20 +1,31 @@
 # Extensions
 
-Boomcatch provides four extension points,which are invoked as a pipeline when a beacon reques tis received. Those extension points,in order of invocation, are:
+Boomcatch provides four extension points, which are invoked as a pipeline when a beacon request is received. Those extension points, in order of invocation, are:
 
-1. [Validators]: These functions are predicates, which can check that the request meets your specific requirements, then signal whether to continue processing or fail the request.
+1. [Validators]: These functions are predicates, which can check that the request meets your specific requirements, then signal whether to continue processing or fail the request. One validator ([permissive]) is available by default.
 
-2. [Filters]: These functions filter out unwanted parts of the data before it is passed to the mapper.
+2. [Filters]: These functions filter out unwanted parts of the data before it is passed to the mapper. One filter ([unfiltered]) is available by default.
 
-3. [Mappers]: These functions transform the data into a format suitable for consumption by some other process.
+3. [Mappers]: These functions transform the data into a format suitable for consumption by some other process. Five mappers ([har], [statsd], [statsd-npg], [unmapped] and [waterfall]) are available out-of-the-box.
 
-4. [Forwarders]: These functions conclude processing by sending the mapped data onto another process.
+4. [Forwarders]: These functions conclude processing by sending the mapped data onto another process. Four forwarders ([console], [file], [http] and [udp]) are available out-of-the-box.
 
 In each case, extensions are loaded with `require`, employing a two-pass approach to enable loading of custom extensions. The first attempt is made with the relevant extension directory prefixed to the module path. If that attempt throws, a second attempt is made using the specified module path verbatim. Thus, standard extensions will be loaded on the first attempt and custom extensions will be loaded on the second.
 
 [validators]: validators/README.md
+[permissive]: validators/permissive.md
 [option]: ../README.md#from-the-command-line
 [filters]: filters/README.md
+[unfiltered]: filters/unfiltered.md
 [data]: data.md
 [mappers]: mappers/README.md
+[har]: mappers/har.md
+[statsd]: mappers/statsd.md
+[statsd-npg]: mappers/statsd-npg.md
+[unmapped]: mappers/unmapped.md
+[waterfall]: mappers/waterfall.md
 [forwarders]: forwarders/README.md
+[console]: forwarders/console.md
+[file]: forwarders/file.md
+[http]: forwarders/http.md
+[udp]: forwarders/udp.md

--- a/doc/filters/unfiltered.md
+++ b/doc/filters/unfiltered.md
@@ -1,0 +1,3 @@
+# filters/unfiltered
+
+The unfiltered filter returns all the data it receives unmodified. This will make all the data received available to the mapper.

--- a/doc/forwarders/README.md
+++ b/doc/forwarders/README.md
@@ -4,7 +4,7 @@ Forwarders are the fourth and final stage of the [extension pipeline][extensions
 
 The choice of forwarder can be specified at the command line, using the `-f` [option].
 
-Three forwarders are available out-of-the-box, [udp], [http], [file] and [console].
+Four forwarders are available out-of-the-box, [udp], [http], [file] and [console].
 
 Defining custom mappers is simple. The [source code for the udp forwarder][src] should be easy to follow, but the basic pattern is to export an interface that looks like this:
 

--- a/doc/validators/permissive.md
+++ b/doc/validators/permissive.md
@@ -1,0 +1,3 @@
+# validators/permissive
+
+The permissive validator always returns `true` without performing any checks on the data. This will make all the requests proceed to the filtering step.


### PR DESCRIPTION
Mainly:

* Add a bit more of detail about the extensions in the README.
* Add the list of default extensions to the extensions main document.
* Correct the number of forwarders.
* Add two new docs for the `unfiltered` filter and the `permissive` validator, as all the other extensions have a document.