### PR TITLE
Replace deprecated worker.suicide

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ function createWorkers (count, options, log) {
     cluster.on('exit', function (worker, code, signal) {
         var exitStatus = getExitStatus(code, signal);
 
-        if (worker.suicide) {
+        if (worker.exitedAfterDisconnect) {
             return log.info('worker ' + worker.process.pid + ' exited (' + exitStatus + ')');
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -3218,7 +3218,7 @@ suite('index:', function () {
                         process: {
                             pid: 1
                         },
-                        suicide: true
+                        exitedAfterDisconnect: true
                     };
                     log.args.on[1][1](worker, null, 3);
                 });


### PR DESCRIPTION
worker.suicide (part of the cluster module) has been renamed to worker.exitedAfterDisconnect