### PR TITLE
Update devDependencies to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
         node-version:
-          - 16.x
+          - 20.x
     steps:
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "ain2": "~2.0.0"
   },
   "devDependencies": {
+    "chai": "~4.5.0",
+    "cheerio": "~1.1.0",
     "jshint": "~2.13.6",
     "mocha": "~11.7.1",
-    "chai": "~4.5.0",
     "mockery": "~2.1.0",
-    "spooks": "~2.0.0",
-    "cheerio": "~1.1.0"
+    "spooks": "~2.0.0"
   },
   "scripts": {
     "lint": "jshint src --config .jshintrc",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   },
   "devDependencies": {
     "jshint": "~2.13.6",
-    "mocha": "~3.0.2",
-    "chai": "~3.0.0",
-    "mockery": "~1.7.0",
+    "mocha": "~11.7.1",
+    "chai": "~5.2.0",
+    "mockery": "~2.1.0",
     "spooks": "~2.0.0",
-    "cheerio": "~0.22.0"
+    "cheerio": "~1.1.0"
   },
   "scripts": {
     "lint": "jshint src --config .jshintrc",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "jshint": "~2.13.6",
     "mocha": "~11.7.1",
-    "chai": "~5.2.0",
+    "chai": "~4.5.0",
     "mockery": "~2.1.0",
     "spooks": "~2.0.0",
     "cheerio": "~1.1.0"


### PR DESCRIPTION
- Update test matrix from Node 16 to a supported version of Node.js (v20).
- Reorder list of devDependencies and update all devDependencies to latest version that doesn't require ESM.
